### PR TITLE
Fix UnicodeDecodeError when a Dictation element contains a word with an ...

### DIFF
--- a/dragonfly/actions/action_base.py
+++ b/dragonfly/actions/action_base.py
@@ -51,10 +51,10 @@ class ActionBase(object):
     # Initialization and aggregation methods.
 
     def __init__(self):
-        self._str = ""
+        self._str = u""
 
-    def __str__(self):
-        return "%s(%s)" % (self.__class__.__name__, self._str)
+    def __unicode__(self):
+        return u"%s(%s)" % (self.__class__.__name__, self._str)
 
     def __add__(self, other):
         return ActionSeries(self, other)
@@ -165,7 +165,7 @@ class BoundAction(ActionBase):
         ActionBase.__init__(self)
         self._action = action
         self._data = data
-        self._str = "%s, %s" % (action, data)
+        self._str = u"%s, %s" % (action, data)
 
     #-----------------------------------------------------------------------
     # Execution methods.

--- a/dragonfly/engines/backend_natlink/dictation.py
+++ b/dragonfly/engines/backend_natlink/dictation.py
@@ -95,7 +95,7 @@ class Word(object):
         if word in self._replacements:
             word, self._info = self._replacements[word]
         else:
-            self._info = natlink.getWordInfo(word)
+            self._info = natlink.getWordInfo(word.encode('latin_1'))
         self._word = word
         index = word.rfind("\\")
         if index == -1:
@@ -198,3 +198,4 @@ class FormatState(object):
         output = "".join(output)
         self._log.debug("Formatted output: %r" % (output,))
         return output
+            

--- a/dragonfly/engines/backend_natlink/engine.py
+++ b/dragonfly/engines/backend_natlink/engine.py
@@ -261,7 +261,7 @@ class GrammarWrapper(object):
         if words == "other":
             func = getattr(self.grammar, "process_recognition_other", None)
             if func:
-                words = tuple(unicode(w) for w in results.getWords(0))
+                words = tuple(unicode(w, 'latin_1') for w in results.getWords(0))
                 func(words)
             return
         elif words == "reject":
@@ -273,7 +273,7 @@ class GrammarWrapper(object):
         # If the words argument was not "other" or "reject", then
         #  it is a sequence of (word, rule_id) 2-tuples.  Convert this
         #  into a tuple of unicode objects.
-        words_rules = tuple((unicode(w), r) for w, r in words)
+        words_rules = tuple((unicode(w, 'latin_1'), r) for w, r in words)
         words = tuple(w for w, r in words_rules)
 
         # Call the grammar's general process_recognition method, if present.

--- a/dragonfly/engines/base/dictation.py
+++ b/dragonfly/engines/base/dictation.py
@@ -74,7 +74,7 @@ class DictationContainerBase(object):
         return unicode(self._formatted)
 
     def __repr__(self):
-        return "%s(%s)" % (self.__class__.__name__, ", ".join(self._words))
+        return  u"%s(%s)" % (self.__class__.__name__, repr(u", ".join(self._words)))
 
     @property
     def words(self):
@@ -84,3 +84,4 @@ class DictationContainerBase(object):
     def format(self):
         """ Format and return this dictation. """
         return u" ".join(self._words)
+            

--- a/dragonfly/grammar/state.py
+++ b/dragonfly/grammar/state.py
@@ -46,11 +46,11 @@ class State(object):
         self._stack = []
         self.initialize_decoding()
 
-    def __str__(self):
+    def __unicode__(self):
         words = self.words()
         before = words[:self._index]
         after = words[self._index:]
-        return " ".join(before) + " >> " + " ".join(after)
+        return u" ".join(before) + u" >> " + u" ".join(after)
 
     #-----------------------------------------------------------------------
     # Methods for accessing recognition content.
@@ -157,12 +157,12 @@ class State(object):
 
     def _log_step(self, parser, message):
         if not self._log_decode: return
-        indent = "   " * self._depth
-        output = "%s%s: %s" % (indent, message, parser)
+        indent = u"   " * self._depth
+        output = u"%s%s: %s" % (indent, message, parser)
         self._log_decode.debug(output)
         if self._index != self._previous_index:
             self._previous_index = self._index
-            output = "%s -- Decoding State: '%s'" % (indent, str(self))
+            output = u"%s -- Decoding State: '%s'" % (indent, unicode(self))
             self._log_decode.debug(output)
 
     #-----------------------------------------------------------------------


### PR DESCRIPTION
...accent, like saute.

There's 2 parts to this:
1. First, dragonfly needs to specify that the encoding coming from Dragon is latin_1, not the default ascii. It also needs to use it when calling C module functions like getWordInfo.
2. In couple places Unicode strings would degrade to regular strings whenever they touched regular strings because Python 2 does implicit conversions.
