### PR TITLE
Add semicolon to list of generated symbols

### DIFF
--- a/documentation/_build_typeables.py
+++ b/documentation/_build_typeables.py
@@ -9,7 +9,7 @@ categories = [
     ("Digits", ["%d" % i for i in range(10)]),
     ("Navigation keys", "left right up down pgup pgdown home end".split()),
     ("Editing keys", "space enter backspace del insert".split()),
-    ("Symbols", "ampersand apostrophe asterisk at backslash backtick bar caret colon comma dollar dot dquote equal escape exclamation hash hyphen minus percent plus question slash squote tilde underscore".split()),
+    ("Symbols", "ampersand apostrophe asterisk at backslash backtick bar caret colon comma dollar dot dquote equal escape exclamation hash hyphen minus percent plus question semicolon slash squote tilde underscore".split()),
     ("Function keys", ["f%d" % i for i in range(1, 25)]),
     ("Modifiers", "alt ctrl shift".split()),
     ("Brackets", "langle lbrace lbracket lparen rangle rbrace rbracket rparen".split()),


### PR DESCRIPTION
This request is pretty self-explanatory. I was in it unable to use the ';' key in dragonfly before this. I would receive an invalid key error. Sequences like "c-semicolon" can now be written.