### PR TITLE
fix anonymous rule naming for compound and mapping rules

### DIFF
--- a/dragonfly/grammar/rule_compound.py
+++ b/dragonfly/grammar/rule_compound.py
@@ -99,14 +99,12 @@ class CompoundRule(Rule):
 
     def __init__(self, name=None, spec=None, extras=None,
                  defaults=None, exported=None, context=None):
-        if name     is None: name     = self._name or self.__class__.__name__
         if spec     is None: spec     = self.spec
         if extras   is None: extras   = self.extras
         if defaults is None: defaults = self.defaults
         if exported is None: exported = self.exported
         if context  is None: context  = self.context
 
-        assert isinstance(name, (str, unicode))
         assert isinstance(spec, (str, unicode))
         assert isinstance(extras, (list, tuple))
         for item in extras:

--- a/dragonfly/grammar/rule_mapping.py
+++ b/dragonfly/grammar/rule_mapping.py
@@ -109,7 +109,6 @@ class MappingRule(Rule):
 
     def __init__(self, name=None, mapping=None, extras=None, defaults=None,
                  exported=None, context=None):
-        if name     is None: name     = self.__class__.__name__
         if mapping  is None: mapping  = self.mapping
         if extras   is None: extras   = self.extras
         if defaults is None: defaults = self.defaults
@@ -126,7 +125,6 @@ class MappingRule(Rule):
             exported = self._default_exported
 
         # Type checking of initialization values.
-        assert isinstance(name, (str, unicode))
         assert isinstance(mapping, dict)
         for key, value in mapping.iteritems():
             assert isinstance(key, (str, unicode))


### PR DESCRIPTION
Mapping and compound rules overwrote anonymous rule naming, which is really annoying if you reuse rule fragments.